### PR TITLE
Put the setuptools library in dependencies due to the use of the pkg_resources module (wemake-services#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 We follow Semantic Versions since the `0.1.0` release.
 
 
+## [Unreleased]
+
+### Bugfixes
+
+- Adds `setuptools` in the dependencies
+
+
 ## 1.2.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ python = "^3.6"
 flake8 = ">=3.5,<5"
 eradicate = "^2.0"
 attrs = "*"
+setuptools = "*"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^3.0"


### PR DESCRIPTION
The distribution version of "flake8-eradicate" is obtained using "pkg_resources.get_distribution" function. So, the "setuptools" library should be added as a runtime dependency.

Note that from Python 3.8 version onwards, the better solution is to use the "[importlib.metadata.version](https://docs.python.org/3/library/importlib.metadata.html)" function which is a standard library. But, "flake8-eradicate" supports Python 3.6 and 3.7 as well, so we should use the third-party equivalent "[importlib-metadata](https://pypi.org/project/importlib-metadata/)" library. But for now, the easiest thing to do is to use the "setuptools" library.